### PR TITLE
Re-enable Mouse Focus Follow Option

### DIFF
--- a/sources/PTYTextView.m
+++ b/sources/PTYTextView.m
@@ -1882,8 +1882,7 @@ static const int kDragThreshold = 3;
 
 - (void)mouseEntered:(NSEvent *)event {
     DLog(@"Mouse entered %@", self);
-    // if ([iTermAdvancedSettingsModel stealKeyFocus] && [iTermPreferences boolForKey:kPreferenceKeyFocusFollowsMouse]) {
-if (YES) {
+    if ([iTermAdvancedSettingsModel stealKeyFocus] && [iTermPreferences boolForKey:kPreferenceKeyFocusFollowsMouse]) {
         DLog(@"Trying to steal key focus");
         if ([self stealKeyFocus]) {
             ++_keyFocusStolenCount;
@@ -1891,8 +1890,7 @@ if (YES) {
         }
     }
     [self updateCursor:event action:[self updateUnderlinedURLs:event]];
-    // if ([iTermPreferences boolForKey:kPreferenceKeyFocusFollowsMouse] && [[self window] alphaValue] > 0 && ![NSApp modalWindow]) {
-    if (YES) {
+    if ([iTermPreferences boolForKey:kPreferenceKeyFocusFollowsMouse] && [[self window] alphaValue] > 0 && ![NSApp modalWindow]) {
         // Some windows automatically close when they lose key status and are
         // incompatible with FFM. Check if the key window or its controller implements
         // disableFocusFollowsMouse and if it returns YES do nothing.


### PR DESCRIPTION
I find this "Focus follows Mouse" extremely annoying, so I don't think it should be hardcoded.
Fix #53 