### PR TITLE
Improve homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ So, in order to get Therm installed in your system you can:
 
 * Install it via brew
 
-	brew install caskroom/cask/therm
+	brew install therm
 
 Future
 ------


### PR DESCRIPTION
caskroom/cask has been moved to homebrew/cask. But you also don't need
to use `brew install cask` or `brew install homebrew/cask` any more.
`brew install` is enough and `brew install --cask` can be used to be
more explicit, but the last one is not needed here.